### PR TITLE
[WIP] : C.H.I.P Pro support

### DIFF
--- a/conf/machine/chippro.conf
+++ b/conf/machine/chippro.conf
@@ -34,4 +34,4 @@ KERNEL_MODULE_AUTOLOAD += " \
 			"
 
 # Include wifi modules and firmware
-MACHINE_EXTRA_RRECOMMENDS = "kernel-module-r8723ds rtl8723ds rtl8723bs-bt axp209"
+MACHINE_EXTRA_RRECOMMENDS += "kernel-module-r8723ds rtl8723ds rtl8723bs-bt axp209"


### PR DESCRIPTION
Fix issue #6 Missing device tree on rootfs for CHIP Pro