### PR TITLE
Fix wifi support for chip pro.

### DIFF
--- a/conf/machine/chippro.conf
+++ b/conf/machine/chippro.conf
@@ -34,4 +34,4 @@ KERNEL_MODULE_AUTOLOAD += " \
 			"
 
 # Include wifi modules and firmware
-MACHINE_EXTRA_RRECOMMENDS = "kernel-module-r8723ds rtl8723ds rtl8723bs-bt axp209"
+MACHINE_EXTRA_RRECOMMENDS += "kernel-module-8723ds rtl8723ds rtl8723bs-bt axp209"

--- a/recipes-kernel/rtl8723ds/rtl8723ds_git.bb
+++ b/recipes-kernel/rtl8723ds/rtl8723ds_git.bb
@@ -30,7 +30,7 @@ EXTRA_OEMAKE += " \
     PREFIX=${D} \
 "
 
-do_install() {
+do_install_append() {
 	install -d ${D}${sysconfdir}/init.d/
 	
         install -m 0755 ${WORKDIR}/wifi.init ${D}${sysconfdir}/init.d/wifi


### PR DESCRIPTION
Fixed do_install_Append in rtl8723ds, and fixed the kernel module name in machine chippro .